### PR TITLE
Corrected setup.py:`REPO`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def install_libc_headers_and(cmdclass):
 
 
 VERSION = '1.1.0'
-REPO    = 'http://github.com/tarruda/autopxd'
+REPO    = 'http://github.com/tarruda/python-autopxd'
 
 
 setup(


### PR DESCRIPTION
The value of `REPO` corresponded to a non-existent repository on GitHub. This fix points it at the correct repository.
