### PR TITLE
Logic for handling typdef enum declarations

### DIFF
--- a/autopxd/__init__.py
+++ b/autopxd/__init__.py
@@ -191,14 +191,16 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
 
     def visit_Enum(self, node):
         items = []
-        for item in node.values.enumerators:
-            items.append(item.name)
+        if node.values:
+            for item in node.values.enumerators:
+                items.append(item.name)
         name = node.name
         type_decl = self.child_of(c_ast.TypeDecl, -2)
         if not name and type_decl:
             name = self.path_name('e')
         # add the enum definition to the top level
-        self.decl_stack[0].append(Enum(name, items))
+        if len(items):
+            self.decl_stack[0].append(Enum(name, items))
         if type_decl:
             self.append(name)
 
@@ -263,7 +265,9 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
         decls = self.collect(node)
         if len(decls) != 1:
             return
-        self.decl_stack[0].append(Type(decls[0]))
+        names = str(decls[0]).split()
+        if names[0] != names[1]:
+            self.decl_stack[0].append(Type(decls[0]))
 
     def collect(self, node):
         decls = []

--- a/test/typedef_enum_alt.test
+++ b/test/typedef_enum_alt.test
@@ -1,0 +1,20 @@
+enum my_enum {
+    C1,
+    C2,
+    C3
+};
+
+typedef enum my_enum my_enum;
+
+typedef my_enum MyEnum;
+
+---
+
+cdef extern from "typedef_enum_alt.test":
+
+    cdef enum my_enum:
+        C1
+        C2
+        C3
+
+    ctypedef my_enum MyEnum


### PR DESCRIPTION
Prior to this commit a specific type of C typedef declaration broke
this tool's functionality.

```
enum tux {
    aa,
    bb,
    cc
};

typedef enum tux tux;
```

Running autopxd on a file contaning this code resulted in an
`'AttributeError: 'NoneType' object has no attribute 'enumerators''`
error and failure to write the pxd file. After these changes the
tool does not generate a ctypedef in this scenario. Initially
only changes to the `visitEnum` function were incorporated which
resulted in a `ctypedef tux tux` declaration but that caused an
incomplete / ambiguous struct error when compiling the associated
pyx file. After these changes this tool will generate the following
in a pxd file associated with the above code snippet.

```
cdef enum tux:
    aa
    bb
    cc
```