### PR TITLE
Catch macOS clang error

### DIFF
--- a/autopxd/__init__.py
+++ b/autopxd/__init__.py
@@ -307,10 +307,16 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
 
 
 def preprocess(code, extra_cpp_args=[]):
-    proc = subprocess.Popen([
-        'cpp', '-nostdinc', '-D__attribute__(x)=', '-I', BUILTIN_HEADERS_DIR,
-    ] + extra_cpp_args + ['-'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     result = []
+    try:
+        proc = subprocess.check_output([
+            'cpp', '-nostdinc', '-D__attribute__(x)=', '-I', BUILTIN_HEADERS_DIR,
+        ] + extra_cpp_args + ['-'], stdin=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        args = [
+        'clang', '-E', '-nostdinc', '-D__attribute__(x)=', '-I' + '"' + BUILTIN_HEADERS_DIR + '"',
+        ]
+        proc = subprocess.Popen(args + extra_cpp_args + ['-'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     result.append(proc.communicate(input=code.encode('utf-8'))[0])
     while proc.poll() is None:
         result.append(proc.communicate()[0])


### PR DESCRIPTION
The clang version that ships with the latest XCode requires a quoted path input to it's `-I` option. This patch is a bit basic – it assumes that if you're running under macOS (`darwin`), that you're using the XCode toolchain, and thus clang.
I'm happy to submit something more robust, but I'm not sure how to do it besides catching the error and retrying.