### PR TITLE
Feature/pxd scope whitelist

### DIFF
--- a/test.py
+++ b/test.py
@@ -18,7 +18,13 @@ def gen(test_file):
     c = c.strip()
     cython = cython.strip() + '\n'
     def test(self):
-        actual = autopxd.translate(c, os.path.basename(test_file))
+        whitelist = None
+        cpp_args = []
+        if test_file == 'test/whitelist.test':
+            test_path = os.path.dirname(test_file)
+            whitelist = ['test/tux_foo.h']
+            cpp_args = ['-I', test_path]
+        actual = autopxd.translate(c, os.path.basename(test_file), cpp_args, whitelist)
         self.assertEqual(cython, actual)
     return test
 

--- a/test/bar_baz.h
+++ b/test/bar_baz.h
@@ -1,0 +1,9 @@
+
+struct bar;
+
+void baz(struct bar *, int a);
+
+struct bar {
+  int a;
+  int b;
+};

--- a/test/tux_foo.h
+++ b/test/tux_foo.h
@@ -1,0 +1,10 @@
+#include "bar_baz.h"
+
+struct tux;
+
+void foo(struct tux *, int a);
+
+struct tux {
+  int a;
+  int b;
+};

--- a/test/whitelist.test
+++ b/test/whitelist.test
@@ -1,0 +1,11 @@
+#include "tux_foo.h"
+
+---
+
+cdef extern from "whitelist.test":
+
+    void foo(tux*, int a)
+
+    cdef struct tux:
+        int a
+        int b


### PR DESCRIPTION
Added logic for whitelist generation.
As a user I've had the desire to generate a .pxd file that
contained mappings from only a few select files. Prior to
this commit it was unclear how to accomplish that. After
this commit a user can utilize a 'whitelist' of only the
files they would like to generate mappings from.

This commit exposes the whitelist functionality to programs that
use the autopxd module through an optional parameter to the translate
function. Further a special case test was added to the test suite along
with test headers required for the functionality to be exercised.