### PR TITLE
[py2.py3] add function to coerce strings to six.binary_type

### DIFF
--- a/autopxd/__init__.py
+++ b/autopxd/__init__.py
@@ -375,4 +375,6 @@ WHITELIST = []
 @click.argument('outfile', type=click.File('wb'), default=sys.stdout)
 def cli(infile, outfile):
     output = translate(infile.read(), infile.name)
-    outfile.write(ensure_binary(output))
+    if outfile is not sys.stdout:
+        output = ensure_binary(output)
+    outfile.write(output)


### PR DESCRIPTION
This patch is required to run python-autopxd on python3, as well as to python2.7 when a header file contains some non-ascii character.

python-autopxd already requires six, however the new `ensure_binary` function is currently only in the six git repository and hasn't been released to PyPI yet, therefore I temporarily copied it here.

The source comes from: https://github.com/benjaminp/six/pull/204

It's a trivial function (every py2.py3 project has its own way to do the same thing).

Fixes #12
Supersedes #3